### PR TITLE
chore: download grpc health binary and pass it directly to docker

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -309,7 +309,7 @@ services:
     <<: *arjuna-backend-default
     image: indrasaputra/arjuna-auth-server:latest
     container_name: arjuna-auth-api
-    command: ["api"]
+    command: ["./auth", "api"]
     depends_on:
       postgres:
         condition: service_healthy
@@ -344,7 +344,7 @@ services:
     <<: *arjuna-backend-default
     image: indrasaputra/arjuna-user-server:latest
     container_name: arjuna-user-api
-    command: ["api"]
+    command: ["./user", "api"]
     depends_on:
       postgres:
         condition: service_healthy
@@ -387,7 +387,7 @@ services:
     <<: *arjuna-backend-default
     image: indrasaputra/arjuna-user-server:latest
     container_name: arjuna-user-worker
-    command: ["worker"]
+    command: ["./user", "worker"]
     depends_on:
       postgres:
         condition: service_healthy
@@ -425,7 +425,7 @@ services:
     <<: *arjuna-backend-default
     image: indrasaputra/arjuna-user-server:latest
     container_name: arjuna-user-relayer
-    command: ["relayer"]
+    command: ["./user", "relayer"]
     depends_on:
       postgres:
         condition: service_healthy
@@ -460,7 +460,7 @@ services:
     <<: *arjuna-backend-default
     image: indrasaputra/arjuna-transaction-server:latest
     container_name: arjuna-transaction-api
-    command: ["api"]
+    command: ["./transaction", "api"]
     depends_on:
       postgres:
         condition: service_healthy
@@ -499,7 +499,7 @@ services:
     <<: *arjuna-backend-default
     image: indrasaputra/arjuna-wallet-server:latest
     container_name: arjuna-wallet-api
-    command: ["api"]
+    command: ["./wallet", "api"]
     depends_on:
       postgres:
         condition: service_healthy

--- a/service/auth/dockerfile/auth.dockerfile
+++ b/service/auth/dockerfile/auth.dockerfile
@@ -5,22 +5,13 @@ ARG CMD=server
 WORKDIR /app
 COPY . .
 RUN if [ ! -f service/${SERVICE}/${OUTPUT_DIR}/${CMD}/${SERVICE} ] ; then make compile svc=${SERVICE} ; fi
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.5 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
-RUN WAIT_FOR_VERSION=v2.1.2 && \
-    wget -qO/bin/wait-for https://github.com/eficode/wait-for/releases/download/${WAIT_FOR_VERSION}/wait-for && \
-    chmod +x /bin/wait-for
+RUN chmod +x /app/bin/grpc_health_probe-linux-amd64-v0.4.28 /app/service/${SERVICE}/${OUTPUT_DIR}/${CMD}/${SERVICE}
 
 FROM alpine:3.16
 ARG SERVICE=auth
 ARG OUTPUT_DIR=deploy/output
 ARG CMD=server
 WORKDIR /app
-COPY --from=builder /bin/grpc_health_probe ./grpc_health_probe
-COPY --from=builder /bin/wait-for ./wait-for
+COPY --from=builder /app/bin/grpc_health_probe-linux-amd64-v0.4.28 ./grpc_health_probe
 COPY --from=builder /app/service/${SERVICE}/${OUTPUT_DIR}/${CMD}/${SERVICE} .
-COPY --from=builder /app/tool/script/start.sh ./start.sh
-RUN chmod +x /app/start.sh /app/wait-for /app/${SERVICE}
 EXPOSE 8002
-ENTRYPOINT ["./auth"]

--- a/service/transaction/dockerfile/transaction.dockerfile
+++ b/service/transaction/dockerfile/transaction.dockerfile
@@ -5,22 +5,13 @@ ARG CMD=server
 WORKDIR /app
 COPY . .
 RUN if [ ! -f service/${SERVICE}/${OUTPUT_DIR}/${CMD}/${SERVICE} ] ; then make compile svc=${SERVICE} ; fi
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.5 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
-RUN WAIT_FOR_VERSION=v2.1.2 && \
-    wget -qO/bin/wait-for https://github.com/eficode/wait-for/releases/download/${WAIT_FOR_VERSION}/wait-for && \
-    chmod +x /bin/wait-for
+RUN chmod +x /app/bin/grpc_health_probe-linux-amd64-v0.4.28 /app/service/${SERVICE}/${OUTPUT_DIR}/${CMD}/${SERVICE}
 
 FROM alpine:3.16
 ARG SERVICE=transaction
 ARG OUTPUT_DIR=deploy/output
 ARG CMD=server
 WORKDIR /app
-COPY --from=builder /bin/grpc_health_probe ./grpc_health_probe
-COPY --from=builder /bin/wait-for ./wait-for
+COPY --from=builder /app/bin/grpc_health_probe-linux-amd64-v0.4.28 ./grpc_health_probe
 COPY --from=builder /app/service/${SERVICE}/${OUTPUT_DIR}/${CMD}/${SERVICE} .
-COPY --from=builder /app/tool/script/start.sh ./start.sh
-RUN chmod +x /app/start.sh /app/wait-for /app/${SERVICE}
 EXPOSE 8003
-ENTRYPOINT ["./transaction"]

--- a/service/user/dockerfile/user.dockerfile
+++ b/service/user/dockerfile/user.dockerfile
@@ -5,22 +5,13 @@ ARG CMD=server
 WORKDIR /app
 COPY . .
 RUN if [ ! -f service/${SERVICE}/${OUTPUT_DIR}/${CMD}/${SERVICE} ] ; then make compile svc=${SERVICE} ; fi
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.5 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
-RUN WAIT_FOR_VERSION=v2.1.2 && \
-    wget -qO/bin/wait-for https://github.com/eficode/wait-for/releases/download/${WAIT_FOR_VERSION}/wait-for && \
-    chmod +x /bin/wait-for
+RUN chmod +x /app/bin/grpc_health_probe-linux-amd64-v0.4.28 /app/service/${SERVICE}/${OUTPUT_DIR}/${CMD}/${SERVICE}
 
 FROM alpine:3.16
 ARG SERVICE=user
 ARG OUTPUT_DIR=deploy/output
 ARG CMD=server
 WORKDIR /app
-COPY --from=builder /bin/grpc_health_probe ./grpc_health_probe
-COPY --from=builder /bin/wait-for ./wait-for
+COPY --from=builder /app/bin/grpc_health_probe-linux-amd64-v0.4.28 ./grpc_health_probe
 COPY --from=builder /app/service/${SERVICE}/${OUTPUT_DIR}/${CMD}/${SERVICE} .
-COPY --from=builder /app/tool/script/start.sh ./start.sh
-RUN chmod +x /app/start.sh /app/wait-for /app/${SERVICE}
 EXPOSE 8001
-ENTRYPOINT ["./user"]

--- a/service/wallet/dockerfile/wallet.dockerfile
+++ b/service/wallet/dockerfile/wallet.dockerfile
@@ -5,22 +5,13 @@ ARG CMD=server
 WORKDIR /app
 COPY . .
 RUN if [ ! -f service/${SERVICE}/${OUTPUT_DIR}/${CMD}/${SERVICE} ] ; then make compile svc=${SERVICE} ; fi
-RUN GRPC_HEALTH_PROBE_VERSION=v0.4.5 && \
-    wget -qO/bin/grpc_health_probe https://github.com/grpc-ecosystem/grpc-health-probe/releases/download/${GRPC_HEALTH_PROBE_VERSION}/grpc_health_probe-linux-amd64 && \
-    chmod +x /bin/grpc_health_probe
-RUN WAIT_FOR_VERSION=v2.1.2 && \
-    wget -qO/bin/wait-for https://github.com/eficode/wait-for/releases/download/${WAIT_FOR_VERSION}/wait-for && \
-    chmod +x /bin/wait-for
+RUN chmod +x /app/bin/grpc_health_probe-linux-amd64-v0.4.28 /app/service/${SERVICE}/${OUTPUT_DIR}/${CMD}/${SERVICE}
 
 FROM alpine:3.16
 ARG SERVICE=wallet
 ARG OUTPUT_DIR=deploy/output
 ARG CMD=server
 WORKDIR /app
-COPY --from=builder /bin/grpc_health_probe ./grpc_health_probe
-COPY --from=builder /bin/wait-for ./wait-for
+COPY --from=builder /app/bin/grpc_health_probe-linux-amd64-v0.4.28 ./grpc_health_probe
 COPY --from=builder /app/service/${SERVICE}/${OUTPUT_DIR}/${CMD}/${SERVICE} .
-COPY --from=builder /app/tool/script/start.sh ./start.sh
-RUN chmod +x /app/start.sh /app/wait-for /app/${SERVICE}
 EXPOSE 8004
-ENTRYPOINT ["./wallet"]


### PR DESCRIPTION
## Chore
- gRPC health probe sometimes takes longer to download
- better to download the binary as it is rarely changed