### PR TITLE
chore: use build tag for integration test

### DIFF
--- a/.github/workflows/reusable-general-quality-ci.yml
+++ b/.github/workflows/reusable-general-quality-ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
       - name: Format proto files using clang-format
-        uses: DoozyX/clang-format-lint-action@v0.11
+        uses: DoozyX/clang-format-lint-action@v0.18.2
         with:
           source: "."
           extensions: "proto"

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ coverage/
 vendor/
 **/cmd/client
 **/cmd/playground
+
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,8 @@ vendor/
 **/cmd/client
 **/cmd/playground
 
+# from https://github.com/indrasaputra/arjuna/pull/55#pullrequestreview-2328166288
+*.prof
+*.swp
 .vscode
+.idea

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "go.buildTags": "integration"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "go.buildTags": "integration"
-}

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,7 +15,7 @@ x-arjuna-backend-default:
 services:
   postgres:
     <<: *default
-    image: postgres:14.6
+    image: postgres:16.4
     container_name: arjuna-postgres
     volumes:
       - ${PWD}/tool/database:/docker-entrypoint-initdb.d

--- a/service/auth/test/integration/helper_test.go
+++ b/service/auth/test/integration/helper_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package integration
 
 import (

--- a/service/auth/test/integration/login_test.go
+++ b/service/auth/test/integration/login_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package integration
 
 import (

--- a/service/auth/test/integration/register_test.go
+++ b/service/auth/test/integration/register_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package integration
 
 import (

--- a/service/transaction/test/integration/create_transaction_test.go
+++ b/service/transaction/test/integration/create_transaction_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package integration
 
 // import (

--- a/service/transaction/test/integration/helper_test.go
+++ b/service/transaction/test/integration/helper_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package integration
 
 // import (

--- a/service/user/test/integration/helper_test.go
+++ b/service/user/test/integration/helper_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package integration
 
 import (

--- a/service/user/test/integration/register_test.go
+++ b/service/user/test/integration/register_test.go
@@ -1,3 +1,6 @@
+//go:build integration
+// +build integration
+
 package integration
 
 import (

--- a/tool/script/format.sh
+++ b/tool/script/format.sh
@@ -13,7 +13,7 @@ done
 for dir in `find . -type d`; do
   if [[ -f ${dir}/go.mod ]]; then
     (cd ${dir} &&
-      goimports -w -local github.com/indrasaputra/arjuna "$(go list -f '{{.Dir}}' -tags integration ./...)" && # from https://github.com/indrasaputra/arjuna/pull/55#pullrequestreview-2328166288
+      goimports -w -local github.com/indrasaputra/arjuna $(go list -f '{{.Dir}}' -tags integration ./...) &&
       gofmt -s -w .)
   fi
 done

--- a/tool/script/format.sh
+++ b/tool/script/format.sh
@@ -13,7 +13,7 @@ done
 for dir in `find . -type d`; do
   if [[ -f ${dir}/go.mod ]]; then
     (cd ${dir} &&
-      goimports -w -local github.com/indrasaputra/arjuna $(go list -f {{.Dir}} -tags integration ./...) &&
+      goimports -w -local github.com/indrasaputra/arjuna "$(go list -f '{{.Dir}}' -tags integration ./...)" && # from https://github.com/indrasaputra/arjuna/pull/55#pullrequestreview-2328166288
       gofmt -s -w .)
   fi
 done

--- a/tool/script/format.sh
+++ b/tool/script/format.sh
@@ -13,7 +13,7 @@ done
 for dir in `find . -type d`; do
   if [[ -f ${dir}/go.mod ]]; then
     (cd ${dir} &&
-      goimports -w -local github.com/indrasaputra/arjuna $(go list -f {{.Dir}} ./...) &&
+      goimports -w -local github.com/indrasaputra/arjuna $(go list -f {{.Dir}} -tags integration ./...) &&
       gofmt -s -w .)
   fi
 done

--- a/tool/script/test.sh
+++ b/tool/script/test.sh
@@ -24,13 +24,13 @@ elif [[ $1 = 'unit' ]]; then
     if [ $2 ]; then
         (cd ./$2 && 
             go clean -testcache &&
-            go test -count=1 -failfast -v -race $(go list ./... | grep -v /test/))
+            go test -count=1 -failfast -v -race ./...)
     else
         for dir in `find . -type d`; do
             if [[ -f ${dir}/go.mod ]]; then
                 (cd ${dir} && 
                     go clean -testcache &&
-                    go test -count=1 -failfast -v -race $(go list ./... | grep -v /test/))
+                    go test -count=1 -failfast -v -race ./...)
             fi
         done
     fi

--- a/tool/script/test.sh
+++ b/tool/script/test.sh
@@ -2,35 +2,35 @@
 
 set -eo pipefail
 
+run_tests() {
+    go clean -testcache
+    go test -count=1 -failfast -v -race ./...
+}
+
+run_tests_cover() {
+    go clean -testcache
+    go test -count=1 -failfast -v -race -coverprofile=coverage.out $(go list ./... | grep -v /test/)
+    go tool cover -html=coverage.out -o coverage.html
+    go tool cover -func coverage.out
+}
+
 if [[ $1 = 'cover' ]]; then
     if [ $2 ]; then
-        (cd ./$2 && 
-            go clean -testcache &&
-            go test -count=1 -failfast -v -race -coverprofile=coverage.out $(go list ./... | grep -v /test/) &&
-            go tool cover -html=coverage.out -o coverage.html &&
-            go tool cover -func coverage.out)
+        (cd ./$2 && run_tests_cover) # from https://github.com/indrasaputra/arjuna/pull/55#pullrequestreview-2328123308
     else
-        for dir in `find . -type d`; do
+        find . -type d | while IFS= read -r dir; do # from https://github.com/indrasaputra/arjuna/pull/55#pullrequestreview-2328123308
             if [[ -f ${dir}/go.mod ]]; then
-                (cd ${dir} && 
-                    go clean -testcache &&
-                    go test -count=1 -failfast -v -race -coverprofile=coverage.out $(go list ./... | grep -v /test/) &&
-                    go tool cover -html=coverage.out -o coverage.html &&
-                    go tool cover -func coverage.out)
+                (cd ${dir} && run_tests_cover) # from https://github.com/indrasaputra/arjuna/pull/55#pullrequestreview-2328123308
             fi
         done
     fi
 elif [[ $1 = 'unit' ]]; then
     if [ $2 ]; then
-        (cd ./$2 && 
-            go clean -testcache &&
-            go test -count=1 -failfast -v -race ./...)
+        (cd ./$2 && run_tests) # from https://github.com/indrasaputra/arjuna/pull/55#pullrequestreview-2328123308
     else
-        for dir in `find . -type d`; do
+        find . -type d | while IFS= read -r dir; do # from https://github.com/indrasaputra/arjuna/pull/55#pullrequestreview-2328123308
             if [[ -f ${dir}/go.mod ]]; then
-                (cd ${dir} && 
-                    go clean -testcache &&
-                    go test -count=1 -failfast -v -race ./...)
+                (cd ${dir} && run_tests) # from https://github.com/indrasaputra/arjuna/pull/55#pullrequestreview-2328123308
             fi
         done
     fi


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new integration testing build constraints across multiple test files, allowing for more targeted testing scenarios.
	- Added a configuration setting to specify integration build tags for Go projects.

- **Bug Fixes**
	- Simplified test execution script to run tests in all directories without filtering out test directories, ensuring comprehensive test coverage.
	- Updated `.gitignore` to include the Visual Studio Code configuration directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->