### PR TITLE
ci: run most of jobs only when event is commit

### DIFF
--- a/.github/workflows/reusable-go-build-ci.yml
+++ b/.github/workflows/reusable-go-build-ci.yml
@@ -43,6 +43,7 @@ on:
 jobs:
   build-push-docker:
     name: Build & push ${{ inputs.service }}-${{ inputs.cmd }} image
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository

--- a/.github/workflows/reusable-go-quality-ci.yml
+++ b/.github/workflows/reusable-go-quality-ci.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   download-module:
     name: Download go module
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -53,6 +54,7 @@ jobs:
 
   security-check:
     name: Semgrep scan
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     container:
       image: semgrep/semgrep
@@ -66,6 +68,7 @@ jobs:
 
   go-code-lint:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push'
     steps:
       - name: Clone repository
         uses: actions/checkout@v4
@@ -82,6 +85,7 @@ jobs:
 
   unit-test-coverage:
     name: Unit test and coverage
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go

--- a/.github/workflows/reusable-html-build-ci.yml
+++ b/.github/workflows/reusable-html-build-ci.yml
@@ -29,6 +29,7 @@ on:
 jobs:
   build-push-docker:
     name: Build & push ${{ inputs.service }}-${{ inputs.cmd }} image
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository


### PR DESCRIPTION
## Summary

run most of jobs only when event is commit

### Description

- run most of jobs only when event is commit
- resolve https://github.com/indrasaputra/arjuna/issues/69

## Summary by Sourcery

CI:
- Limit the execution of most CI jobs to push events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI/CD Workflow Updates**
	- Added conditional execution for Docker build jobs to run only on push events
	- Updated GitHub Actions workflows for Go and HTML build processes to improve workflow control and efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->