### PR TITLE
chore: update go version

### DIFF
--- a/.github/workflows/reusable-go-compile-ci.yml
+++ b/.github/workflows/reusable-go-compile-ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.22.x
+          go-version: ^1.25.x
       - name: Clone repository
         uses: actions/checkout@v4
       - uses: actions/cache@v4

--- a/.github/workflows/reusable-go-quality-ci.yml
+++ b/.github/workflows/reusable-go-quality-ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.22.x
+          go-version: ^1.25.x
       - name: Clone repository
         uses: actions/checkout@v4
       - name: Download module
@@ -75,11 +75,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.22.x
+          go-version: ^1.25.x
       - name: Lint using golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: v1.63.4
+          version: v2.6.0
           args: --config=${GITHUB_WORKSPACE}/.golangci.yml
           working-directory: ${{ inputs.target }}
 
@@ -91,7 +91,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: ^1.22.x
+          go-version: ^1.25.x
       - name: Clone repository
         uses: actions/checkout@v4
       # TODO: move this after lint

--- a/gateway/dockerfile/gateway.dockerfile
+++ b/gateway/dockerfile/gateway.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.25 AS builder
 ARG SERVICE=gateway
 ARG OUTPUT_DIR=deploy/output
 ARG CMD=server

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -1,6 +1,6 @@
 module github.com/indrasaputra/arjuna/gateway
 
-go 1.22.4
+go 1.25.3
 
 replace (
 	github.com/indrasaputra/arjuna/pkg/sdk v0.0.0 => ../pkg/sdk

--- a/pkg/sdk/go.mod
+++ b/pkg/sdk/go.mod
@@ -1,6 +1,6 @@
 module github.com/indrasaputra/arjuna/pkg/sdk
 
-go 1.22.4
+go 1.25.3
 
 replace (
 	github.com/indrasaputra/arjuna/pkg/sdk v0.0.0 => ../../pkg/sdk

--- a/service/auth/dockerfile/auth.dockerfile
+++ b/service/auth/dockerfile/auth.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.25 AS builder
 ARG SERVICE=auth
 ARG OUTPUT_DIR=deploy/output
 ARG CMD=server

--- a/service/auth/go.mod
+++ b/service/auth/go.mod
@@ -1,6 +1,6 @@
 module github.com/indrasaputra/arjuna/service/auth
 
-go 1.22.4
+go 1.25.3
 
 replace (
 	github.com/indrasaputra/arjuna/pkg/sdk v0.0.0 => ../../pkg/sdk

--- a/service/transaction/dockerfile/transaction.dockerfile
+++ b/service/transaction/dockerfile/transaction.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.25 AS builder
 ARG SERVICE=transaction
 ARG OUTPUT_DIR=deploy/output
 ARG CMD=server

--- a/service/transaction/go.mod
+++ b/service/transaction/go.mod
@@ -1,6 +1,6 @@
 module github.com/indrasaputra/arjuna/service/transaction
 
-go 1.22.4
+go 1.25.3
 
 replace (
 	github.com/indrasaputra/arjuna/pkg/sdk v0.0.0 => ../../pkg/sdk

--- a/service/user/dockerfile/user.dockerfile
+++ b/service/user/dockerfile/user.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.25 AS builder
 ARG SERVICE=user
 ARG OUTPUT_DIR=deploy/output
 ARG CMD=server

--- a/service/user/go.mod
+++ b/service/user/go.mod
@@ -1,6 +1,6 @@
 module github.com/indrasaputra/arjuna/service/user
 
-go 1.22.4
+go 1.25.3
 
 replace (
 	github.com/indrasaputra/arjuna/pkg/sdk v0.0.0 => ../../pkg/sdk

--- a/service/wallet/dockerfile/wallet.dockerfile
+++ b/service/wallet/dockerfile/wallet.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS builder
+FROM golang:1.25 AS builder
 ARG SERVICE=wallet
 ARG OUTPUT_DIR=deploy/output
 ARG CMD=server

--- a/service/wallet/go.mod
+++ b/service/wallet/go.mod
@@ -1,6 +1,6 @@
 module github.com/indrasaputra/arjuna/service/wallet
 
-go 1.22.4
+go 1.25.3
 
 replace (
 	github.com/indrasaputra/arjuna/pkg/sdk v0.0.0 => ../../pkg/sdk


### PR DESCRIPTION
## Summary

Update to Go 1.25.3

### Description

Update to Go 1.25.3

## Summary by Sourcery

Build:
- Update Go version in go.mod files across all modules to 1.25.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Go toolchain version across all services and the SDK to a newer release.
  * Updated builder images to use the newer Go toolchain for builds.
  * Updated CI workflows to use the newer Go version and upgraded the Go linting action for improved pipeline consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->